### PR TITLE
only install certbot from repositories (don't update)

### DIFF
--- a/tasks/install-RedHat-7.yml
+++ b/tasks/install-RedHat-7.yml
@@ -1,4 +1,4 @@
 - name: RHEL7 | Install certbot
   yum:
     name: certbot
-    state: latest
+    state: present

--- a/tasks/install-Ubuntu-16.yml
+++ b/tasks/install-Ubuntu-16.yml
@@ -1,5 +1,4 @@
 - name: UBUNTU16 | Install certbot-auto
   apt:
     name: letsencrypt
-    state: latest
-    update_cache: yes
+    state: present


### PR DESCRIPTION
For people having any kind of update management in place, ansible
shouldn't update any packages. Without updating packages apt cache
does not need to be updated as well which makes for clean ansible
run statistics (currently installation task is in state changed on
every run, which could mean only a cache update or the package
was actually updated).